### PR TITLE
Fix Timestamps to match user's Timezone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,6 @@ __work__/
 
 # misc
 *.log
-mail-backup.yaml
+*.yaml
 
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,17 @@ Eml-Files can be viewed at least with Thunderbird, even extracting attachments.
 - Download emails via IMAP as eml files.
 - Configure local storage paths and file names based on email attributes (like date).
 - Handles duplicated backups.
-- Limit/filter by "last days" number.
+- Limit/filter by "newer than x days" number.
+- Limit/filter by "older than x days" number.
+- Delete files from server after backup
 
 Tipp: You may search your emails with a desktop search app, like [Recoll](https://www.lesbonscomptes.com/recoll/).
 
 
 ## Disclaimer
 
-- Tested only on Linux. There is no plan to support Windows, even though there should be only minor issues with path handling.
-- Some (minimal) experience with the Linux command line and YAML files required!
+- Tested only on Linux and macOS. There is no plan to support Windows, even though there should be only minor issues with path handling.
+- Some (minimal) experience with the UNIX command line and YAML files required!
 
 
 ## Start up
@@ -60,23 +62,27 @@ You may configure the storage path per email attributes. Available replacement t
 
 Example:
 ```
-./downloaded/{YEAR}-{MONTH}/{YEAR}{MONTH}{DAY}-{HOUR}{MINUTE}-IN-{FROM}-{SUBJECT}-{UID}.eml
+../{FOLDER}/{YEAR}{MONTH}{DAY}-{HOUR}{MINUTE}-{FROM}-{SUBJECT}-{UID}.eml
 ```
 Gets to:
 ```
-./downloaded/2021-04/20210401-1604-IN-no-reply.company.com-The.subject-123.eml
+./info@example.com/INBOX/20210401-1604-no-reply.company.com-The.subject-123.eml
 ```
 Not existing paths get created automatically. 
 
 All attribute strings get preprocessed in a quite opinionated manner, e.g. UTF-8 characters and white space gets removed. "Fwd:", "Re:" in subjects are removed too.
 
-The handling of already existing mails files can be configured. Just set `when_exists` in `imap_folders` (see [mail-backup.yaml.sample](./mail-backup.yaml.sample)). Available options: 
+The handling of already existing mails files can be configured. Just set `when_exists` (see [mail-backup.yaml.sample](./mail-backup.yaml.sample)). Available options: 
 - `skip`: Skip the email backup if a file with the proposed name already exists. 
 - `overwrite`: Overwrite the email backup if a file with the proposed name already exists.
 - `compare`: Even by using the `UID`, there is no guarantee that different emails get different file names, so emails could get overwritten. 
   In `compare` mode existing files gets compared with downloaded email content and written with a postfixed path ("mail.eml" => "mail.2.eml"). 
 
-With `last_days` in `imap_folders` you can limit the backup to the most recent emails (see [mail-backup.yaml.sample](./mail-backup.yaml.sample)).
+With `last_days` you can limit the backup to the most recent emails (see [mail-backup.yaml.sample](./mail-backup.yaml.sample)).
+
+With `limit_days` you can limit the backup to only backup emails older than specified days (see [mail-backup.yaml.sample](./mail-backup.yaml.sample)).
+
+With `delete` you can define to delete the mails from the server. You will be promped on execution to confirm this!
 
 
 ### Run

--- a/mail-backup.sh
+++ b/mail-backup.sh
@@ -10,16 +10,10 @@ cd "$SCRIPT_DIR"
 
 VENV_ACTIVATE="./venv/bin/activate"
 if [ ! -f "$VENV_ACTIVATE" ] ; then
-	echo -e "$SCRIPT_NAME\nerror: venv environment doesn't exist!"
-	exit 1
+	echo "$SCRIPT_NAME\nvenv environment doesn't exist. Creating and installing dependencies..."
+	python -m venv venv
+	./venv/bin/pip install --upgrade -r requirements.txt
 fi
 
-source "$VENV_ACTIVATE"
-RC=$?
-if [ $RC -ne 0 ] ; then
-	echo -e "$SCRIPT_NAME\nerror: activating environment failed!"
-	exit 1
-fi
-
-python ./mail_backup.py $@
+./venv/bin/python ./mail_backup.py $@
 exit $?

--- a/mail-backup.yaml.sample
+++ b/mail-backup.yaml.sample
@@ -5,21 +5,8 @@ imap_host:          "your.host"
 imap_username:      "your.email"
 imap_password:      "your.password"
 
-imap_folders:
-  # there is a good change, that these folder settings match your needs.
-  # but in case you need to adapt the folder names and are not sure about: start the app and watch the output for "found mail folders".
-
-  - folder_name:    "INBOX"
-    path:           "./downloaded/{YEAR}-{MONTH}/{YEAR}{MONTH}{DAY}-{HOUR}{MINUTE}-IN-{FROM}-{SUBJECT}-{UID}.eml"
-    # last_days:    7  # only download emails from the last x days
-    when_exists:    "compare"  # skip, overwrite, compare
-
-  - folder_name:    "Sent"
-    path:           "./downloaded/{YEAR}-{MONTH}/{YEAR}{MONTH}{DAY}-{HOUR}{MINUTE}-OUT-{TO1}-{SUBJECT}-{UID}.eml"
-    # last_days:    7  # only download emals from the last x days
-    when_exists:    "compare"  # skip, overwrite, compare
-
-  - folder_name:    "Sent Items"
-    path:           "./downloaded/{YEAR}-{MONTH}/{YEAR}{MONTH}{DAY}-{HOUR}{MINUTE}-OUT-{TO1}-{SUBJECT}-{UID}.eml"
-    # last_days:    7  # only download emals from the last x days
-    when_exists:    "compare"  # skip, overwrite, compare
+path:           "../{FOLDER}/{YEAR}{MONTH}{DAY}-{HOUR}{MINUTE}-{SUBJECT}-{FROM}-{UID}.eml"
+# last_days:    7  # only download emails newer the last x days
+# limit_days:   365  # only download emails older than last x days
+delete:         false  # delete files on server after download
+when_exists:    "compare"  # skip, overwrite, compare

--- a/mail-backup.yaml.sample
+++ b/mail-backup.yaml.sample
@@ -3,7 +3,7 @@
 
 imap_host:          "your.host"
 imap_username:      "your.email"
-imap_password:      "your.password"
+imap_password:      "your.password"  # leave blank to be asked on execution. It's never a good idea to save passwords in plain text!!!
 
 path:           "../{FOLDER}/{YEAR}{MONTH}{DAY}-{HOUR}{MINUTE}-{SUBJECT}-{FROM}-{UID}.eml"
 # last_days:    7  # only download emails newer the last x days

--- a/src/config.py
+++ b/src/config.py
@@ -23,7 +23,11 @@ class ConfigKey(Enum):
     IMAP_PORT = "imap_port"
     IMAP_USERNAME = "imap_username"
     IMAP_PASSWORD = "imap_password"
-    IMAP_FOLDERS = "imap_folders"
+    PATH = "path"
+    LAST_DAYS = "last_days"
+    LIMIT_DAYS = "limit_days"
+    DELETE = "delete"
+    WHEN_EXISTS = "when_exists"
 
 
 class Config:

--- a/src/naming_key.py
+++ b/src/naming_key.py
@@ -11,6 +11,7 @@ class NamingKey(Enum):
     SUBJECT = "SUBJECT"
     TO1 = "TO1"
     FROM = "FROM"
+    FOLDER = "FOLDER"
 
     DATETIME_OBJ = "DATETIME_OBJ"
 

--- a/src/naming_utils.py
+++ b/src/naming_utils.py
@@ -110,7 +110,7 @@ class NamingUtils:
         add_to_attributes(NamingKey.TO1, cls.prepare_email(mail.to))
         add_to_attributes(NamingKey.SUBJECT, cls.prepare_subject(mail.subject), 50)
 
-        date = mail.date
+        date = mail.date.astimezone(tz=datetime.now().astimezone().tzinfo)
         if date.year < 1971:
             date = datetime(0, 1, 1, 0, 0, 0)
 

--- a/src/naming_utils.py
+++ b/src/naming_utils.py
@@ -54,6 +54,33 @@ class NamingUtils:
         return value
 
     @classmethod
+    def prepare_path(cls, value, max_length=MAX_ATTRIBUTE_LENGTH) -> str:
+        if value is None:
+            return ""
+
+        value = unidecode(str(value).strip())
+
+        def replace_all(text, old, new):
+            while True:
+                orig_text = text
+                text = text.replace(old, new)
+                if orig_text == text:
+                    break
+            return text
+
+        value = replace_all(value, ".", "/")
+
+        regex = re.compile("[^a-zA-Z0-9-./]")
+        value = regex.sub('', value)  # First parameter is the replacement, second parameter is your input string
+
+        value = replace_all(value, "..", ".")
+
+        value = value[:max_length]
+        value = value.strip(".")
+
+        return value
+
+    @classmethod
     def prepare_email(cls, value) -> str:
         if value is None:
             return ""
@@ -107,7 +134,7 @@ class NamingUtils:
 
         # Copy servers folderstructure
         folder = folder.replace('INBOX.', '')
-        folder = cls.prepare_text(folder, cls.MAX_ATTRIBUTE_LENGTH)
+        folder = cls.prepare_path(folder, cls.MAX_ATTRIBUTE_LENGTH)
         attributes[NamingKey.FOLDER.name] = username + (f"/{folder}" if folder else "")
 
         add_to_attributes(NamingKey.UID, mail.uid)

--- a/src/runner.py
+++ b/src/runner.py
@@ -7,6 +7,7 @@ import signal
 import socket
 from enum import Enum
 from typing import List, Optional
+from getpass import getpass
 
 from imap_tools import MailBox, AND
 
@@ -72,6 +73,8 @@ class Runner:
     def _connect(self):
         username = Config.get_str(self._config, ConfigKey.IMAP_USERNAME)
         password = Config.get_str(self._config, ConfigKey.IMAP_PASSWORD)
+        if not password:
+            password = getpass(f"Enter you IMAP Password for {username}: ")
         if not self._host or not username or not password:
             raise MessageException("empty IMAP credentials!")
 

--- a/src/time_utils.py
+++ b/src/time_utils.py
@@ -1,0 +1,7 @@
+import datetime
+
+def parse_time(dt: datetime) -> datetime:
+   if dt.year < 1971:
+      dt = datetime(0, 1, 1, 0, 0, 0)
+   dt = dt.astimezone(tz=datetime.datetime.now().astimezone().tzinfo)
+   return dt


### PR DESCRIPTION
In one and the same mailbox I had mails with different timezones in the datetime object.
I managed to fix the timestamp in the resulting filepath by changing the timezone to the system's timezone.